### PR TITLE
fix(tracking): correctly average when a motor is unplugged

### DIFF
--- a/src/tracking/sensor.rs
+++ b/src/tracking/sensor.rs
@@ -40,16 +40,20 @@ impl RotarySensor for Vec<Motor> {
 
     fn position(&self) -> Result<Position, Self::Error> {
         let mut degree_sum = 0.0;
+        // The total motors to be used in the average later
+        let mut total_motors = self.len();
 
         for motor in self.iter() {
             degree_sum += if let Ok(position) = motor.position() {
                 position.as_degrees()
             } else {
+                // Since this motor isn't being counted in the average, decrement the count
+                total_motors -= 1;
                 continue;
             };
         }
 
-        Ok(Position::from_degrees(degree_sum / (self.len() as f64)))
+        Ok(Position::from_degrees(degree_sum / (total_motors as f64)))
     }
 }
 


### PR DESCRIPTION
This adds another byte of memory to this function's memory usage! Sorry!

Right now, if a motor is unplugged, because its position isn't included in the sum for the average for a `Vec<Motor>`'s `RotarySensor` implementation, it throws off the average. This PR fixes that by not including the motor in the total count of motors. (See the code for a more clear explanation than natural language).

I haven't actually tested this on real hardware.