### PR TITLE
Multiple inertial support

### DIFF
--- a/packages/evian-tracking/src/lib.rs
+++ b/packages/evian-tracking/src/lib.rs
@@ -51,7 +51,6 @@ pub mod wheeled;
 pub use sensor::RotarySensor;
 
 use evian_math::{Angle, Vec2};
-use vexide::devices::smart::imu::{InertialError, InertialSensor};
 
 /// A tracking system that localizes a robot's 2D position.
 ///
@@ -114,28 +113,4 @@ pub trait TracksForwardTravel {
     /// Positive values indicate forward movement from the origin of tracking, while negative
     /// values indicate backwards movement from the origin.
     fn forward_travel(&self) -> f64;
-}
-
-/// A "gyroscope," or a sensor that measures the robot's heading and angular velocity
-pub trait Gyro {
-    /// The error returned when [`Gyro::heading`] or [`Gyro::angular_velocity`] fails. This
-    /// describes a hardware error.
-    type Error;
-
-    /// Returns the heading of the robot as an [`Angle`]
-    fn heading(&self) -> Result<Angle, Self::Error>;
-    /// Returns the horizontal angular velocity
-    fn angular_velocity(&self) -> Result<f64, Self::Error>;
-}
-
-impl Gyro for InertialSensor {
-    type Error = InertialError;
-
-    fn heading(&self) -> Result<Angle, Self::Error> {
-        InertialSensor::heading(self).map(Angle::from_radians)
-    }
-
-    fn angular_velocity(&self) -> Result<f64, Self::Error> {
-        InertialSensor::gyro_rate(self).map(|rate| rate.z)
-    }
 }

--- a/packages/evian-tracking/src/sensor.rs
+++ b/packages/evian-tracking/src/sensor.rs
@@ -1,6 +1,8 @@
 use core::cell::RefCell;
 
 use alloc::{rc::Rc, vec::Vec};
+use evian_math::Angle;
+use vexide::devices::smart::imu::{InertialError, InertialSensor};
 use vexide::devices::{
     PortError,
     adi::AdiEncoder,
@@ -126,5 +128,39 @@ impl<T: RotarySensor> RotarySensor for Rc<RefCell<T>> {
 
     fn position(&self) -> Result<Position, Self::Error> {
         self.borrow().position()
+    }
+}
+
+/// A "gyroscope," or a sensor that measures the robot's heading and angular velocity
+pub trait Gyro {
+    /// The error returned when [`Gyro::heading`] or [`Gyro::angular_velocity`] fails. This
+    /// describes a hardware error.
+    type Error;
+
+    /// Returns the heading of the robot as an [`Angle`]
+    fn heading(&self) -> Result<Angle, Self::Error>;
+    /// Returns the horizontal angular velocity
+    fn angular_velocity(&self) -> Result<f64, Self::Error>;
+}
+
+impl Gyro for InertialSensor {
+    type Error = InertialError;
+
+    fn heading(&self) -> Result<Angle, Self::Error> {
+        InertialSensor::heading(self).map(Angle::from_radians)
+    }
+
+    fn angular_velocity(&self) -> Result<f64, Self::Error> {
+        InertialSensor::gyro_rate(self).map(|rate| rate.z)
+    }
+}
+impl<const N: usize> Gyro for [InertialSensor; N] {
+    type Error = [Option<InertialError>; N];
+
+    fn angular_velocity(&self) -> Result<f64, Self::Error> {
+        Ok(1.0)
+    }
+    fn heading(&self) -> Result<Angle, Self::Error> {
+        Ok(Angle::from_degrees(1.0))
     }
 }

--- a/packages/evian-tracking/src/wheeled.rs
+++ b/packages/evian-tracking/src/wheeled.rs
@@ -13,8 +13,8 @@ use vexide::{
     time::Instant,
 };
 
-use crate::{Gyro, sensor::RotarySensor};
 use crate::{TracksForwardTravel, TracksHeading, TracksPosition};
+use crate::{sensor::Gyro, sensor::RotarySensor};
 
 use super::TracksVelocity;
 


### PR DESCRIPTION
Adds support for multiple inertials, allowing for reduced noise, and more accurate heading readings. Overall a very useful feature missing from most motion libraries

![image](https://github.com/user-attachments/assets/81924954-a5d8-489c-885f-8c7e1fda0238)
![image](https://github.com/user-attachments/assets/4ac7e3d1-a5eb-4678-96ce-673bc7451e05)

Example, module and library both build


Negatives:

- changes example to use multiple inertials
- Untested on actual robot
- could be expanded upon to be more generic