### PR TITLE
fixed desaturate

### DIFF
--- a/packages/evian-math/src/lib.rs
+++ b/packages/evian-math/src/lib.rs
@@ -14,7 +14,7 @@ pub fn desaturate<const N: usize>(values: [f64; N], max: f64) -> [f64; N] {
     let largest_magnitude = values.iter().map(|v| v.abs()).fold(0.0, f64::max);
 
     if largest_magnitude > max {
-        values.map(|v| v / largest_magnitude)
+        values.map(|v| v * max / largest_magnitude)
     } else {
         values
     }


### PR DESCRIPTION
Fixes desaturate so that values get properly scaled. I assume this hasn't caused an issue since most of its uses in evian have a max of 1.